### PR TITLE
Add brand UI primitives (Button, Panel) and theme tokens

### DIFF
--- a/src/components/CreateRoom/CreateRoom.tsx
+++ b/src/components/CreateRoom/CreateRoom.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import supabase from '../../utils/supabase';
 import { generateRoomId } from '../../utils/generateRoomId';
 import { RoomLink } from '../RoomLink/RoomLink';
+import { Button } from '../ui/Button';
+import { Panel } from '../ui/Panel';
 
 type GameState = {
   cards: never[];
@@ -75,46 +77,41 @@ export const CreateRoom = () => {
       <div className="mx-auto max-w-md">
         <h1 className="mb-8 text-center text-3xl font-bold">Create a New Game</h1>
 
-        {!roomCode ? (
-          <form onSubmit={createRoom} className="space-y-6">
-            <div>
-              <label htmlFor="nickname" className="mb-2 block text-lg">
-                Your Nickname
-              </label>
-              <input
-                id="nickname"
-                type="text"
-                value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
-                className="w-full rounded-lg bg-gray-700 px-4 py-2 text-white"
-                required
-                minLength={2}
-                maxLength={20}
-              />
+        <Panel>
+          {!roomCode ? (
+            <form onSubmit={createRoom} className="space-y-6">
+              <div>
+                <label htmlFor="nickname" className="mb-2 block text-lg">
+                  Your Nickname
+                </label>
+                <input
+                  id="nickname"
+                  type="text"
+                  value={nickname}
+                  onChange={(e) => setNickname(e.target.value)}
+                  className="w-full rounded-lg bg-surface-input px-4 py-2 text-white"
+                  required
+                  minLength={2}
+                  maxLength={20}
+                />
+              </div>
+
+              {error && <p className="text-center text-red-500">{error}</p>}
+
+              <Button type="submit" disabled={isCreating} className="w-full py-3 text-base">
+                {isCreating ? 'Creating...' : 'Create Room'}
+              </Button>
+            </form>
+          ) : (
+            <div className="space-y-6">
+              <RoomLink roomId={roomCode} />
+
+              <Button onClick={startGame} className="w-full py-3 text-base">
+                Start Game
+              </Button>
             </div>
-
-            {error && <p className="text-center text-red-500">{error}</p>}
-
-            <button
-              type="submit"
-              disabled={isCreating}
-              className="w-full rounded-lg bg-blue-600 py-3 text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-            >
-              {isCreating ? 'Creating...' : 'Create Room'}
-            </button>
-          </form>
-        ) : (
-          <div className="space-y-6">
-            <RoomLink roomId={roomCode} />
-
-            <button
-              onClick={startGame}
-              className="w-full rounded-lg bg-green-600 py-3 text-white transition-colors hover:bg-green-700"
-            >
-              Start Game
-            </button>
-          </div>
-        )}
+          )}
+        </Panel>
       </div>
     </div>
   );

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -1,4 +1,5 @@
 import { Card } from '../Card/Card';
+import { Button } from '../ui/Button';
 import { useEffect } from 'react';
 import {
   HigherLowerOrSame,
@@ -136,8 +137,8 @@ export const Game = () => {
 
         {gameState.isGameOver && (
           <div className="mt-8 flex">
-            <button
-              className="cursor-pointer rounded-lg bg-white px-4 py-2 text-lg font-bold text-black shadow-md active:translate-y-1"
+            <Button
+              variant="ghost"
               onClick={() =>
                 dispatch({
                   type: 'DRAW_CARDS',
@@ -147,7 +148,7 @@ export const Game = () => {
               }
             >
               {gameState.hasWon ? 'Another Ride?' : 'Redraw Cards'}
-            </button>
+            </Button>
           </div>
         )}
 

--- a/src/components/JoinRoom/JoinRoom.tsx
+++ b/src/components/JoinRoom/JoinRoom.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import supabase from '../../utils/supabase';
+import { Button } from '../ui/Button';
+import { Panel } from '../ui/Panel';
 
 type GameState = {
   cards: never[];
@@ -89,38 +91,36 @@ export const JoinRoom = () => {
       <div className="mx-auto max-w-md">
         <h1 className="mb-8 text-center text-3xl font-bold">Join Game</h1>
 
-        <div className="mb-8 rounded-lg bg-gray-800 p-4 text-center">
-          <h2 className="mb-2 text-xl font-bold">Room Code</h2>
-          <p className="font-mono text-2xl">{roomCode}</p>
-        </div>
-
-        <form onSubmit={joinRoom} className="space-y-6">
-          <div>
-            <label htmlFor="nickname" className="mb-2 block text-lg">
-              Your Nickname
-            </label>
-            <input
-              id="nickname"
-              type="text"
-              value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
-              className="w-full rounded-lg bg-gray-700 px-4 py-2 text-white"
-              required
-              minLength={2}
-              maxLength={20}
-            />
+        <Panel className="space-y-6">
+          <div className="rounded-lg bg-surface p-4 text-center">
+            <h2 className="mb-2 text-xl font-bold">Room Code</h2>
+            <p className="font-mono text-2xl">{roomCode}</p>
           </div>
 
-          {error && <p className="text-center text-red-500">{error}</p>}
+          <form onSubmit={joinRoom} className="space-y-6">
+            <div>
+              <label htmlFor="nickname" className="mb-2 block text-lg">
+                Your Nickname
+              </label>
+              <input
+                id="nickname"
+                type="text"
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                className="w-full rounded-lg bg-surface-input px-4 py-2 text-white"
+                required
+                minLength={2}
+                maxLength={20}
+              />
+            </div>
 
-          <button
-            type="submit"
-            disabled={isJoining}
-            className="w-full rounded-lg bg-blue-600 py-3 text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-          >
-            {isJoining ? 'Joining...' : 'Join Game'}
-          </button>
-        </form>
+            {error && <p className="text-center text-red-500">{error}</p>}
+
+            <Button type="submit" disabled={isJoining} className="w-full py-3 text-base">
+              {isJoining ? 'Joining...' : 'Join Game'}
+            </Button>
+          </form>
+        </Panel>
       </div>
     </div>
   );

--- a/src/components/LongestRides/LongestRides.tsx
+++ b/src/components/LongestRides/LongestRides.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getDailyWorstScores } from '../../api/getDailyWorstScores';
+import { Panel } from '../ui/Panel';
 
 export const LongestRides = () => {
   const [worstScores, setWorstScores] = useState<any[]>([]);
@@ -18,7 +19,7 @@ export const LongestRides = () => {
   const hasScores = worstScores.length > 0;
 
   return (
-    <div className="mx-auto flex max-w-[600px] min-w-[300px] flex-col gap-4 rounded-lg border-1 border-black bg-[#1a2531] p-5 shadow-md">
+    <Panel className="mx-auto flex max-w-[600px] min-w-[300px] flex-col gap-4">
       <div>
         <p className="text-center text-2xl font-bold">Longest Rides</p>
         <p className="text-center italic">Past 24 hours</p>
@@ -39,6 +40,6 @@ export const LongestRides = () => {
           </li>
         ))}
       </ul>
-    </div>
+    </Panel>
   );
 };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,23 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'dark';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'bg-brand text-white hover:bg-brand-hover',
+  secondary: 'bg-amber-600 text-white hover:bg-amber-700',
+  ghost: 'bg-white text-black hover:bg-gray-100',
+  dark: 'bg-black text-white hover:bg-gray-900',
+};
+
+export const Button = ({ variant = 'primary', className = '', ...props }: ButtonProps) => {
+  return (
+    <button
+      {...props}
+      className={`cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md transition-colors active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50 ${variantClasses[variant]} ${className}`}
+    />
+  );
+};

--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes } from 'react';
+
+interface PanelProps extends HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export const Panel = ({ children, className = '', ...props }: PanelProps) => {
+  return (
+    <div
+      {...props}
+      className={`rounded-lg border border-black bg-surface-raised p-5 shadow-md ${className}`}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,15 @@
   --breakpoint-2xl: 100rem;
   --breakpoint-3xl: 120rem;
   --color-red: #ff0000;
+
+  /* Brand surfaces */
+  --color-surface: #22303f;
+  --color-surface-raised: #1a2531;
+  --color-surface-input: #374151;
+
+  /* Brand actions */
+  --color-brand: #dc2626;
+  --color-brand-hover: #b91c1c;
 }
 
 :root {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, useNavigate } from 'react-router-dom';
 import supabase from '../utils/supabase';
+import { Button } from '../components/ui/Button';
 
 export const Login = () => {
   const [email, setEmail] = useState('');
@@ -97,13 +98,14 @@ export const Login = () => {
           {error && <div className="text-left text-sm text-red-500">{error}</div>}
 
           <div>
-            <button
+            <Button
               type="submit"
+              variant="secondary"
               disabled={loading}
-              className="group relative flex w-full justify-center rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:cursor-pointer hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              className="w-full justify-center text-sm"
             >
               {loading ? 'Signing in...' : 'Sign in'}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import supabase from '../utils/supabase';
 import type { Database } from '../types/database.types';
 import { uploadAvatar } from '../api/uploadAvatar';
+import { Button } from '../components/ui/Button';
 
 type Profile = Database['public']['Tables']['profiles']['Insert'];
 
@@ -197,13 +198,14 @@ export const SignUp = () => {
           {error && <div className="text-left text-sm text-red-500">{error}</div>}
 
           <div>
-            <button
+            <Button
               type="submit"
+              variant="secondary"
               disabled={loading}
-              className="group relative flex w-full justify-center rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:cursor-pointer hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              className="w-full justify-center text-sm"
             >
               {loading ? 'Creating account...' : 'Create account'}
-            </button>
+            </Button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary

- Adds `Button` and `Panel` components under `src/components/ui/` to codify the RideTheBus brand
- Expands Tailwind `@theme` in `index.css` with semantic color tokens: `surface`, `surface-raised`, `surface-input`, `brand`, `brand-hover`
- Wires new primitives into `CreateRoom`, `JoinRoom`, `LongestRides`, `Login`, and `SignUp`
- Game-mechanics buttons (Red/Black, Higher/Lower/Same, suits) intentionally kept as raw elements — they reflect game state, not brand theme

## Button variants
| Variant | Color | Used for |
|---|---|---|
| `primary` | Brand red | Room create/join CTAs |
| `secondary` | Amber | Login / Sign Up |
| `ghost` | White | Redraw / Another Ride |
| `dark` | Black | (available for future use) |

## Test plan
- [ ] Home page loads and game plays normally — Red/Black and suit buttons unchanged
- [ ] Create Room form renders with Panel + red primary button
- [ ] Join Room form renders with Panel + red primary button
- [ ] Login and Sign Up submit buttons render in amber (secondary)
- [ ] Longest Rides leaderboard renders with Panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only refactor introducing reusable components and swapping a few existing buttons/containers to use them; primary risk is small styling/regression differences in affected screens.
> 
> **Overview**
> Introduces brand UI primitives `Button` (variants: `primary`/`secondary`/`ghost`/`dark`) and `Panel`, plus new Tailwind theme color tokens for semantic *surface* and *brand* styling.
> 
> Refactors `CreateRoom`, `JoinRoom`, `LongestRides`, `Login`, `SignUp`, and the game over redraw action in `Game` to use the new components and updated surface/input classes, standardizing look-and-feel without changing underlying behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d764c82d4c4934666a59cfe010a3b362ce18670f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->