### PR TITLE
Add TanStack Query for data fetching (issue #11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 - React 18.3 + TypeScript + Vite
 - Tailwind CSS v4 (`@tailwindcss/vite` plugin — no `tailwind.config.js`)
 - React Router v7, Supabase, Radix UI, Recharts, React Helmet Async
+- TanStack Query v5 (data fetching / caching layer)
 
 ## Project structure
 ```
@@ -13,6 +14,7 @@ src/
   pages/             # Layout, Login, SignUp, PartyBus, Beerdle, Stats, Profile
   contexts/          # AuthContext
   api/               # Supabase API helpers
+  lib/               # shared singletons: queryClient.ts, queryKeys.ts
   utils/             # utility functions
   types/             # TypeScript types
   index.css          # global styles + @theme token definitions
@@ -77,6 +79,14 @@ theme, and should stay independent.
 2. Stage specific files by name (never `git add -A`)
 3. Commit message: imperative title + blank line + body explaining *why*
 4. Push branch → `gh pr create --draft` with a test plan checklist in the body
+
+## TanStack Query conventions
+- `QueryClient` singleton lives in `src/lib/queryClient.ts` (staleTime 5 min, retry 1)
+- All query keys live in `src/lib/queryKeys.ts` — always use these for queries **and** invalidations
+- `dailySeed` query uses `staleTime: Infinity` (seed never changes mid-day)
+- **Intentionally NOT migrated:** `AuthContext` (realtime auth subscription), `PartyBus` (realtime
+  Supabase channel), `Login`/`SignUp` (fire-and-forget mutations, no caching value)
+- No devtools installed
 
 ## Claude-specific notes
 - **Worktrees do not inherit `.env`** — if you see `supabaseUrl is required`, copy it over:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-icons": "^1.3.2",
         "@supabase/supabase-js": "^2.49.1",
         "@tailwindcss/vite": "4.1.18",
+        "@tanstack/react-query": "^5.90.21",
         "react": "^18.3.1",
         "react-confetti": "^6.2.2",
         "react-dom": "^18.3.1",
@@ -87,7 +88,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1975,6 +1975,30 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2130,7 +2154,6 @@
       "integrity": "sha512-fcdJqaHOMDbiAwJnXv6XCzX0jDW77yI3tJqYh1Byn8EL5/S628WRx9b/y3DnNe55zTukUQKrfYxiZls2dHcUMw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2142,7 +2165,6 @@
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2192,7 +2214,6 @@
       "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.27.0",
         "@typescript-eslint/types": "8.27.0",
@@ -2376,7 +2397,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2646,7 +2666,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3383,7 +3402,6 @@
       "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5395,7 +5413,6 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5532,7 +5549,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5560,7 +5576,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6427,7 +6442,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6552,7 +6566,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
       "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@supabase/supabase-js": "^2.49.1",
     "@tailwindcss/vite": "4.1.18",
+    "@tanstack/react-query": "^5.90.21",
     "react": "^18.3.1",
     "react-confetti": "^6.2.2",
     "react-dom": "^18.3.1",

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 min
+      retry: 1,
+    },
+  },
+});

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,8 @@
+export const queryKeys = {
+  cardCounts: ['cardCounts'] as const,
+  dailySeed: ['dailySeed'] as const,
+  profile: (username: string) => ['profile', username] as const,
+  userScores: (userId: string) => ['userScores', userId] as const,
+  userBeerdleStats: (userId: string) => ['userBeerdleStats', userId] as const,
+  todayBeerdleScore: (userId: string) => ['todayBeerdleScore', userId] as const,
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,8 +12,11 @@ import { AuthProvider } from './contexts/AuthContext';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { Profile } from './pages/Profile.tsx';
 import { HelmetProvider } from 'react-helmet-async';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './lib/queryClient';
 
 createRoot(document.getElementById('root')!).render(
+  <QueryClientProvider client={queryClient}>
   <HelmetProvider>
     <BrowserRouter>
       <AuthProvider>
@@ -48,5 +51,6 @@ createRoot(document.getElementById('root')!).render(
         </Routes>
       </AuthProvider>
     </BrowserRouter>
-  </HelmetProvider>,
+  </HelmetProvider>
+  </QueryClientProvider>,
 );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,67 +1,66 @@
-import { useEffect, useState, useRef } from 'react';
+import { useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { getProfileByUsername } from '../api/getProfileByUsername';
 import { getUserScores } from '../api/getUserScores';
-import { getUserBeerdleStats, BeerdleStats } from '../api/getUserBeerdleStats';
+import { getUserBeerdleStats } from '../api/getUserBeerdleStats';
 import { Database } from '../types/database.types';
 import { useAuth } from '../contexts/AuthContext';
 import supabase from '../utils/supabase';
 import { uploadAvatar } from '../api/uploadAvatar';
 import { Helmet } from 'react-helmet-async';
+import { queryClient } from '../lib/queryClient';
+import { queryKeys } from '../lib/queryKeys';
 
 type Profile = Database['public']['Tables']['profiles']['Row'];
 type Score = Database['public']['Tables']['scores']['Row'];
 
 export const Profile = () => {
   const { username } = useParams<{ username: string }>();
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [scores, setScores] = useState<Score[]>([]);
-  const [beerdleStats, setBeerdleStats] = useState<BeerdleStats | null>(null);
-  const [error, setError] = useState<string>('');
-  const [loading, setLoading] = useState(true);
-  const [updating, setUpdating] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { user } = useAuth();
   const navigate = useNavigate();
 
+  const {
+    data: profile,
+    isLoading,
+    error,
+  } = useQuery<Profile>({
+    queryKey: queryKeys.profile(username!),
+    queryFn: () => getProfileByUsername(username!),
+    enabled: !!username,
+  });
+
+  const { data: scores = [] } = useQuery<Score[]>({
+    queryKey: queryKeys.userScores(profile?.id ?? ''),
+    queryFn: () => getUserScores(profile!.id),
+    enabled: !!profile?.id,
+    select: (data) =>
+      [...data].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      ),
+  });
+
+  const { data: beerdleStats = null } = useQuery({
+    queryKey: queryKeys.userBeerdleStats(profile?.id ?? ''),
+    queryFn: () => getUserBeerdleStats(profile!.id),
+    enabled: !!profile?.id,
+  });
+
+  const avatarMutation = useMutation({
+    mutationFn: async ({ file, profileId }: { file: File; profileId: string }) => {
+      const { publicUrl } = await uploadAvatar(file, profileId);
+      const { error } = await supabase
+        .from('profiles')
+        .update({ avatar_url: publicUrl })
+        .eq('id', profileId);
+      if (error) throw error;
+      return publicUrl;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.profile(username!) }),
+  });
+
   const isOwnProfile = user?.id === profile?.id;
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        if (!username) {
-          throw new Error(
-            "What is this, a profile page without a username? That's like a horse without a... actually, never mind.",
-          );
-        }
-
-        const profileData = await getProfileByUsername(username);
-        setProfile(profileData);
-
-        const userScores = await getUserScores(profileData.id);
-        setScores(
-          userScores.sort(
-            (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-          ),
-        );
-
-        // Fetch Beerdle stats
-        try {
-          const beerdleData = await getUserBeerdleStats(profileData.id);
-          setBeerdleStats(beerdleData);
-        } catch {
-          // Beerdle stats are optional, don't fail the whole page
-          console.log('Could not fetch Beerdle stats');
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Something went wrong');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [username]);
 
   const handleAvatarClick = () => {
     if (isOwnProfile && fileInputRef.current) {
@@ -72,29 +71,10 @@ export const Profile = () => {
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !profile) return;
-
-    setUpdating(true);
-    try {
-      const { publicUrl } = await uploadAvatar(file, profile.id);
-
-      // Update the profile with new avatar URL
-      const { error: updateError } = await supabase
-        .from('profiles')
-        .update({ avatar_url: publicUrl })
-        .eq('id', profile.id);
-
-      if (updateError) throw updateError;
-
-      // Update local state
-      setProfile((prev) => (prev ? { ...prev, avatar_url: publicUrl } : null));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update avatar');
-    } finally {
-      setUpdating(false);
-    }
+    avatarMutation.mutate({ file, profileId: profile.id });
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-xl">Loading...</div>
@@ -103,7 +83,6 @@ export const Profile = () => {
   }
 
   if (error) {
-    // Redirect to home page
     navigate('/');
   }
 
@@ -144,7 +123,7 @@ export const Profile = () => {
             <>
               <div className="bg-opacity-50 absolute inset-0 flex items-center justify-center rounded-full bg-black opacity-0 transition-opacity group-hover:opacity-100">
                 <span className="text-sm text-white">
-                  {updating ? 'Updating...' : 'Change Avatar'}
+                  {avatarMutation.isPending ? 'Updating...' : 'Change Avatar'}
                 </span>
               </div>
               <input
@@ -153,7 +132,7 @@ export const Profile = () => {
                 className="hidden"
                 accept="image/*"
                 onChange={handleAvatarChange}
-                disabled={updating}
+                disabled={avatarMutation.isPending}
               />
             </>
           )}

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Helmet } from 'react-helmet-async';
 import { getCardCounts } from '../api/getCardCounts';
 import { CardCountBarChart } from '../components/CardCountBarChart/CardCountBarChart';
 import { CardCountTable } from '../components/CardCountTable/CardCountTable';
+import { queryKeys } from '../lib/queryKeys';
 
 export type CardCount = {
   card_rank: string;
@@ -14,9 +16,13 @@ const RANK_ORDER = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K',
 const SUIT_ORDER = ['CLUBS', 'DIAMONDS', 'SPADES', 'HEARTS'];
 
 export const Stats = (): JSX.Element => {
-  const [cardCounts, setCardCounts] = useState<CardCount[]>([]);
   const [sortCriteria, setSortCriteria] = useState<'rank' | 'suit' | 'count'>('rank');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+
+  const { data: cardCounts = [] } = useQuery({
+    queryKey: queryKeys.cardCounts,
+    queryFn: getCardCounts,
+  });
 
   const sortCardCounts = (counts: CardCount[]) => {
     return counts.sort((a, b) => {
@@ -51,15 +57,6 @@ export const Stats = (): JSX.Element => {
       name: `${cardCount.card_rank} of ${cardCount.card_suit}`,
     };
   });
-
-  useEffect(() => {
-    const fetchCardCounts = async () => {
-      const counts = await getCardCounts();
-      setCardCounts(sortCardCounts(counts));
-    };
-
-    fetchCardCounts();
-  }, []);
 
   return (
     <div className="p-4">


### PR DESCRIPTION
## Summary

- Install `@tanstack/react-query` v5 and wire up `QueryClientProvider` in `main.tsx`
- Add `src/lib/queryClient.ts` (5-min staleTime, retry: 1) and `src/lib/queryKeys.ts` (centralised key factory)
- Migrate **Stats**, **Profile**, and **BeerdleGame** from manual `useState`/`useEffect` fetching to `useQuery` / `useMutation`
- `dailySeed` query uses `staleTime: Infinity` — seed never changes mid-day
- Avatar upload mutation invalidates the profile query on success so the UI refreshes from cache
- Score-save mutation replaces the reactive `useEffect`; guards against double-fire with `isPending` / `isSuccess`
- Intentionally **not** migrated: `AuthContext` (realtime subscription), `PartyBus` (realtime channel), `Login`/`SignUp` (fire-and-forget)
- Update `CLAUDE.md` with TanStack Query conventions and updated `src/lib/` directory

## Test plan

- [ ] `npm install` — clean install, no errors
- [ ] `npx tsc --noEmit` — zero type errors
- [ ] `/stats` — card count table and chart load; sort by Rank/Suit/Count and Ascending/Descending all work
- [ ] `/<username>/profile` — profile header, Beerdle stats block, and scores table all render
- [ ] `/<username>/profile` (own profile) — avatar upload shows "Updating…" while in flight and refreshes the avatar after success
- [ ] `/beerdle` (logged in, no score today) — seed loads, game plays through all four rounds, win modal shows and score is saved
- [ ] `/beerdle` (logged in, already completed today) — "Already Completed" view renders with correct score/drinks
- [ ] `/beerdle` (logged out) — game plays, win modal shows; no score query fires (check Network tab — no `todayBeerdleScore` request)
- [ ] Hard-refresh `/beerdle` after winning — "Already Completed" view, not a fresh game

🤖 Generated with [Claude Code](https://claude.com/claude-code)