### PR TITLE
Add No Hands mode (premium)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,9 @@ Buttons in `Game.tsx` tied to game state (Red/Black, Higher/Lower/Same, Inside/O
 intentionally do **not** use the Button component. Their colors reflect game rules, not brand
 theme, and should stay independent.
 
+## Copy & text rules
+- **Never use em dashes** (`—`) anywhere in UI copy, button text, or JSX strings. Use a regular hyphen, reword the sentence, or just end it.
+
 ## Git & PR workflow
 1. `npx tsc --noEmit` — must be clean
 2. Stage specific files by name (never `git add -A`)

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   HigherLowerOrSame,
   InsideOutsideOrSame,
+  NoHandsPreset,
   RedOrBlack,
   suits,
   useGameState,
@@ -16,22 +17,33 @@ import { postScore } from '../../api/postScore';
 import { LongestRides } from '../LongestRides/LongestRides';
 import { postCardCounts } from '../../api/postCardCounts';
 import { useAuth } from '../../contexts/AuthContext';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { getProfileById } from '../../api/getProfileById';
 import { queryKeys } from '../../lib/queryKeys';
 import { getConfettiColors } from '../../utils/countryColors';
 import { Link } from '@tanstack/react-router';
 import { MedalTable } from '../MedalTable/MedalTable';
+import { NoHandsMode } from './NoHandsMode';
+import supabase from '../../utils/supabase';
+import { queryClient } from '../../lib/queryClient';
 
 const COUNTRY_PROMPT_KEY = 'country_prompt_dismissed';
+const NO_HANDS_ACTIVE_KEY = 'no_hands_active';
+// Delay between auto-played rounds (ms)
+const ROUND_DELAY = 1200;
+// Longer pause after an incorrect guess so the user can take their drink
+const DRINK_DELAY = 3000;
 
 export const Game = () => {
   const { user } = useAuth();
   const { width, height } = useDocumentSize();
   const [promptDismissed, setPromptDismissed] = useState(true);
+  const [noHandsActive, setNoHandsActive] = useState(false);
+  const noHandsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setPromptDismissed(localStorage.getItem(COUNTRY_PROMPT_KEY) === '1');
+    setNoHandsActive(localStorage.getItem(NO_HANDS_ACTIVE_KEY) === '1');
   }, []);
 
   const { gameState, dispatch, finalRound, firstRound, secondRound, thirdRound } = useGameState();
@@ -42,6 +54,27 @@ export const Game = () => {
     queryFn: () => getProfileById(user!.id),
     enabled: !!user?.id,
   });
+
+  const noHandsPreset = (currentProfile?.no_hands_preset as NoHandsPreset | null | undefined) ?? null;
+
+  const noHandsPresetMutation = useMutation({
+    mutationFn: async (preset: NoHandsPreset) => {
+      if (!user) throw new Error('Not logged in');
+      const { error } = await supabase
+        .from('profiles')
+        .update({ no_hands_preset: preset })
+        .eq('id', user.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.profileById(user!.id) });
+    },
+  });
+
+  const handleToggleNoHands = (active: boolean) => {
+    setNoHandsActive(active);
+    localStorage.setItem(NO_HANDS_ACTIVE_KEY, active ? '1' : '0');
+  };
 
   const userCountry = currentProfile?.country ?? null;
   const isPerfectRide = gameState.hasWon && gameState.timesRedrawn === 0;
@@ -84,6 +117,40 @@ export const Game = () => {
       postCardCounts(gameState.cards);
     }
   }, [gameState.isGameOver, gameState.cards]);
+
+  // No Hands: auto-play the current round after a brief pause
+  useEffect(() => {
+    if (!noHandsActive || !noHandsPreset || gameState.cards.length === 0 || gameState.isGameOver) {
+      return;
+    }
+    if (noHandsTimerRef.current) clearTimeout(noHandsTimerRef.current);
+    noHandsTimerRef.current = setTimeout(() => {
+      switch (gameState.currentRound) {
+        case 1: firstRound(noHandsPreset.round1); break;
+        case 2: secondRound(noHandsPreset.round2); break;
+        case 3: thirdRound(noHandsPreset.round3); break;
+        case 4: finalRound(noHandsPreset.round4); break;
+      }
+    }, ROUND_DELAY);
+    return () => {
+      if (noHandsTimerRef.current) clearTimeout(noHandsTimerRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [noHandsActive, noHandsPreset, gameState.currentRound, gameState.cards.length, gameState.isGameOver]);
+
+  // No Hands: auto-redraw after a miss — pause so the user can drink, then loop again.
+  // On a win, stop and let the user restart manually.
+  useEffect(() => {
+    if (!noHandsActive || !gameState.isGameOver || gameState.hasWon) return;
+    if (noHandsTimerRef.current) clearTimeout(noHandsTimerRef.current);
+    noHandsTimerRef.current = setTimeout(() => {
+      dispatch({ type: 'DRAW_CARDS', amountToDraw: 4, resetScore: false });
+    }, DRINK_DELAY);
+    return () => {
+      if (noHandsTimerRef.current) clearTimeout(noHandsTimerRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [noHandsActive, gameState.isGameOver, gameState.hasWon]);
 
   const renderButtons = () => {
     switch (gameState.currentRound) {
@@ -180,7 +247,7 @@ export const Game = () => {
           ))}
         </div>
 
-        {gameState.isGameOver && (
+        {gameState.isGameOver && (!noHandsActive || gameState.hasWon) && (
           <div className="mt-8 flex">
             <Button
               variant="ghost"
@@ -197,12 +264,18 @@ export const Game = () => {
           </div>
         )}
 
-        {!gameState.isGameOver && <div className="mt-8 flex gap-5">{renderButtons()}</div>}
+        {!gameState.isGameOver && !noHandsActive && (
+          <div className="mt-8 flex gap-5">{renderButtons()}</div>
+        )}
 
         {gameState.isGameOver && (
           <p className="mt-8 text-lg font-bold">
             {gameState.hasWon ? 'You won!' : 'Take a drink!'}
           </p>
+        )}
+
+        {noHandsActive && !gameState.isGameOver && (
+          <p className="mt-8 text-sm text-amber-400/70 italic">No Hands is driving...</p>
         )}
 
         {gameState.cards.length > 0 && (
@@ -233,6 +306,16 @@ export const Game = () => {
               ✕
             </button>
           </div>
+        )}
+
+        {currentProfile?.is_premium && user && (
+          <NoHandsMode
+            isActive={noHandsActive}
+            preset={noHandsPreset}
+            isSaving={noHandsPresetMutation.isPending}
+            onToggle={handleToggleNoHands}
+            onSavePreset={(preset) => noHandsPresetMutation.mutate(preset)}
+          />
         )}
 
         <div className="mt-8 flex flex-wrap justify-center gap-5">

--- a/src/components/Game/NoHandsMode.tsx
+++ b/src/components/Game/NoHandsMode.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  NoHandsPreset,
+  RedOrBlack,
+  HigherLowerOrSame,
+  InsideOutsideOrSame,
+  Suit,
+  suits,
+} from './useGameState';
+
+interface Props {
+  isActive: boolean;
+  preset: NoHandsPreset | null;
+  isSaving: boolean;
+  onToggle: (active: boolean) => void;
+  onSavePreset: (preset: NoHandsPreset) => void;
+}
+
+const ROUND1_OPTIONS: RedOrBlack[] = ['red', 'black'];
+const ROUND2_OPTIONS: HigherLowerOrSame[] = ['higher', 'lower', 'same'];
+const ROUND3_OPTIONS: InsideOutsideOrSame[] = ['inside', 'outside', 'same'];
+
+const formatSuit = (suit: Suit) => suit.charAt(0) + suit.slice(1).toLowerCase();
+const formatLabel = (val: string) => val.charAt(0).toUpperCase() + val.slice(1).toLowerCase();
+
+const DEFAULT_DRAFT: NoHandsPreset = {
+  round1: 'red',
+  round2: 'higher',
+  round3: 'inside',
+  round4: 'HEARTS',
+};
+
+const presetSummary = (p: NoHandsPreset) =>
+  `${formatLabel(p.round1)} · ${formatLabel(p.round2)} · ${formatLabel(p.round3)} · ${formatSuit(p.round4)}`;
+
+export const NoHandsMode = ({ isActive, preset, isSaving, onToggle, onSavePreset }: Props) => {
+  const [showSetup, setShowSetup] = useState(false);
+  const [draft, setDraft] = useState<NoHandsPreset>(preset ?? DEFAULT_DRAFT);
+
+  const handleOpenSetup = () => {
+    setDraft(preset ?? DEFAULT_DRAFT);
+    setShowSetup(true);
+  };
+
+  const handleSave = () => {
+    onSavePreset(draft);
+    setShowSetup(false);
+  };
+
+  const inactive = 'border border-gray-600 text-gray-400 hover:border-gray-400 hover:text-white';
+
+  const redBlackClass = (opt: RedOrBlack, selected: boolean) =>
+    selected
+      ? `cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md text-white ${opt === 'red' ? 'bg-red-600' : 'bg-black'}`
+      : `cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md transition-colors ${inactive}`;
+
+  const whiteClass = (selected: boolean) =>
+    selected
+      ? 'cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md bg-white text-black'
+      : `cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md transition-colors ${inactive}`;
+
+  const suitClass = (suit: Suit, selected: boolean) => {
+    const isRed = suit === 'HEARTS' || suit === 'DIAMONDS';
+    return selected
+      ? `cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md text-white ${isRed ? 'bg-red-600' : 'bg-black'}`
+      : `cursor-pointer rounded-lg px-4 py-2 text-lg font-bold shadow-md transition-colors ${inactive}`;
+  };
+
+  const modal = showSetup && (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) setShowSetup(false); }}
+    >
+      <div className="w-full max-w-sm rounded-xl border border-amber-600/40 bg-surface-raised p-5 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-semibold text-amber-400">🙌 Call your shot</p>
+            <p className="mt-0.5 text-xs text-gray-400">Pick one answer per round. The bus drives itself. You just drink.</p>
+          </div>
+          <button
+            className="text-gray-500 hover:text-white transition-colors"
+            onClick={() => setShowSetup(false)}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <p className="mb-2 text-xs text-gray-500">Round 1</p>
+            <div className="grid grid-cols-2 gap-2">
+              {ROUND1_OPTIONS.map((opt) => (
+                <button
+                  key={opt}
+                  className={redBlackClass(opt, draft.round1 === opt)}
+                  onClick={() => setDraft((d) => ({ ...d, round1: opt }))}
+                >
+                  {formatLabel(opt)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs text-gray-500">Round 2</p>
+            <div className="grid grid-cols-3 gap-2">
+              {ROUND2_OPTIONS.map((opt) => (
+                <button
+                  key={opt}
+                  className={whiteClass(draft.round2 === opt)}
+                  onClick={() => setDraft((d) => ({ ...d, round2: opt }))}
+                >
+                  {formatLabel(opt)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs text-gray-500">Round 3</p>
+            <div className="grid grid-cols-3 gap-2">
+              {ROUND3_OPTIONS.map((opt) => (
+                <button
+                  key={opt}
+                  className={whiteClass(draft.round3 === opt)}
+                  onClick={() => setDraft((d) => ({ ...d, round3: opt }))}
+                >
+                  {formatLabel(opt)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs text-gray-500">Round 4</p>
+            <div className="grid grid-cols-2 gap-2">
+              {suits.map((suit) => (
+                <button
+                  key={suit}
+                  className={suitClass(suit, draft.round4 === suit)}
+                  onClick={() => setDraft((d) => ({ ...d, round4: suit }))}
+                >
+                  {formatSuit(suit)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 flex gap-2">
+          <button
+            className="flex-1 rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 disabled:opacity-60 transition-colors"
+            onClick={handleSave}
+            disabled={isSaving}
+          >
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            className="rounded-lg border border-gray-600 px-3 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+            onClick={() => setShowSetup(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {showSetup && createPortal(modal, document.body)}
+
+      <div className="mt-6 flex items-center gap-3 rounded-md border border-amber-600/40 bg-amber-900/10 px-3 py-2">
+        <span className="text-sm font-semibold text-amber-400">🙌 No Hands</span>
+
+        {preset ? (
+          <>
+            <span className="flex-1 text-xs text-gray-400">{presetSummary(preset)}</span>
+            <button
+              className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              onClick={handleOpenSetup}
+            >
+              Edit
+            </button>
+            <div
+              className={`relative h-5 w-9 cursor-pointer rounded-full transition-colors ${isActive ? 'bg-amber-600' : 'bg-gray-600'}`}
+              onClick={() => onToggle(!isActive)}
+            >
+              <div
+                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${isActive ? 'translate-x-4' : 'translate-x-0.5'}`}
+              />
+            </div>
+          </>
+        ) : (
+          <button
+            className="rounded border border-amber-600/60 px-2 py-0.5 text-xs text-amber-400 hover:border-amber-500 hover:text-amber-300 transition-colors"
+            onClick={handleOpenSetup}
+          >
+            Set up
+          </button>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/components/Game/useGameState.ts
+++ b/src/components/Game/useGameState.ts
@@ -6,10 +6,17 @@ import {
   validateFinalRound,
 } from '../../utils/gameValidation';
 
-type Suit = 'HEARTS' | 'DIAMONDS' | 'CLUBS' | 'SPADES';
+export type Suit = 'HEARTS' | 'DIAMONDS' | 'CLUBS' | 'SPADES';
 export type RedOrBlack = 'red' | 'black';
 export type HigherLowerOrSame = 'higher' | 'lower' | 'same';
 export type InsideOutsideOrSame = 'inside' | 'outside' | 'same';
+
+export type NoHandsPreset = {
+  round1: RedOrBlack;
+  round2: HigherLowerOrSame;
+  round3: InsideOutsideOrSame;
+  round4: Suit;
+};
 
 type Value = {
   rank: string;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -467,7 +467,7 @@ export const Profile = () => {
             <div className="rounded-md border border-gray-600 p-4 text-center">
               <p className="mb-1 text-sm font-semibold text-gray-200">🍻 Go Premium</p>
               <p className="mb-3 text-xs text-gray-400">
-                Custom card backs plus No Hands mode. Call your shots and let the bus drive itself.
+                Custom card backs, No Hands mode, and more (hopefully).
               </p>
               <button
                 className="w-full rounded-md bg-amber-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-500 disabled:opacity-60"

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -387,7 +387,7 @@ export const Profile = () => {
         <div className="mx-auto mb-8 w-full max-w-xs">
           {profile.is_premium ? (
             <div className="rounded-md border border-amber-600/50 bg-amber-900/20 p-4">
-              <p className="mb-3 text-sm font-semibold text-amber-400">💎 Premium — Custom Card Back</p>
+              <p className="mb-3 text-sm font-semibold text-amber-400">🍻 Premium — Custom Card Back</p>
               {profile.card_back_url ? (
                 <div className="mb-3 flex flex-col items-center gap-2">
                   <button
@@ -465,7 +465,7 @@ export const Profile = () => {
             </div>
           ) : (
             <div className="rounded-md border border-gray-600 p-4 text-center">
-              <p className="mb-1 text-sm font-semibold text-gray-200">💎 Go Premium</p>
+              <p className="mb-1 text-sm font-semibold text-gray-200">🍻 Go Premium</p>
               <p className="mb-3 text-xs text-gray-400">
                 Custom card backs plus No Hands mode. Call your shots and let the bus drive itself.
               </p>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -466,8 +466,11 @@ export const Profile = () => {
           ) : (
             <div className="rounded-md border border-gray-600 p-4 text-center">
               <p className="mb-1 text-sm font-semibold text-gray-200">🍻 Go Premium</p>
-              <p className="mb-3 text-xs text-gray-400">
+              <p className="mb-1 text-xs text-gray-400">
                 Custom card backs, No Hands mode, and more (hopefully).
+              </p>
+              <p className="mb-3 text-xs text-gray-400">
+                Use code <span className="font-bold text-amber-400">HOTDOG</span> for 50% off.
               </p>
               <button
                 className="w-full rounded-md bg-amber-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-500 disabled:opacity-60"

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -477,7 +477,7 @@ export const Profile = () => {
                 onClick={handleStartCheckout}
                 disabled={checkoutLoading || !user}
               >
-                {checkoutLoading ? 'Redirecting...' : 'Upgrade — $5 lifetime'}
+                {checkoutLoading ? 'Redirecting...' : 'Upgrade for $5 lifetime'}
               </button>
               {!user && (
                 <p className="mt-2 text-xs text-gray-500">Sign in to upgrade</p>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -298,7 +298,7 @@ export const Profile = () => {
                 onClick={() => setShowCountryPicker(true)}
               >
                 {profile.country
-                  ? `${getFlagEmoji(profile.country)} ${getCountryName(profile.country)} — Change`
+                  ? `${getFlagEmoji(profile.country)} ${getCountryName(profile.country)} (change)`
                   : '🌍 Set your country'}
               </button>
             ) : (
@@ -387,7 +387,7 @@ export const Profile = () => {
         <div className="mx-auto mb-8 w-full max-w-xs">
           {profile.is_premium ? (
             <div className="rounded-md border border-amber-600/50 bg-amber-900/20 p-4">
-              <p className="mb-3 text-sm font-semibold text-amber-400">🍻 Premium — Custom Card Back</p>
+              <p className="mb-3 text-sm font-semibold text-amber-400">🍻 Premium: Custom Card Back</p>
               {profile.card_back_url ? (
                 <div className="mb-3 flex flex-col items-center gap-2">
                   <button

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -387,7 +387,7 @@ export const Profile = () => {
         <div className="mx-auto mb-8 w-full max-w-xs">
           {profile.is_premium ? (
             <div className="rounded-md border border-amber-600/50 bg-amber-900/20 p-4">
-              <p className="mb-3 text-sm font-semibold text-amber-400">✨ Premium — Custom Card Back</p>
+              <p className="mb-3 text-sm font-semibold text-amber-400">💎 Premium — Custom Card Back</p>
               {profile.card_back_url ? (
                 <div className="mb-3 flex flex-col items-center gap-2">
                   <button
@@ -465,9 +465,9 @@ export const Profile = () => {
             </div>
           ) : (
             <div className="rounded-md border border-gray-600 p-4 text-center">
-              <p className="mb-1 text-sm font-semibold text-gray-200">✨ Premium Card Backs</p>
+              <p className="mb-1 text-sm font-semibold text-gray-200">💎 Go Premium</p>
               <p className="mb-3 text-xs text-gray-400">
-                Upload any image as your card back — visible in all your games.
+                Custom card backs plus No Hands mode. Call your shots and let the bus drive itself.
               </p>
               <button
                 className="w-full rounded-md bg-amber-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-500 disabled:opacity-60"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -84,7 +84,7 @@ function HomePage() {
           >
             ✕
           </button>
-          <p className="font-semibold text-amber-400">💎 Go Premium</p>
+          <p className="font-semibold text-amber-400">🍻 Go Premium</p>
           <p className="mt-0.5 text-gray-300">Custom card backs, No Hands mode, and more (hopefully).</p>
           <p className="mt-1 text-gray-300">
             Use <span className="font-bold text-amber-400">HOTDOG</span> for 50% off

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ import { getProfileById } from '../api/getProfileById';
 import { queryKeys } from '../lib/queryKeys';
 import supabase from '../utils/supabase';
 
-const PREMIUM_BANNER_KEY = 'premium_banner_dismissed';
+const PREMIUM_BANNER_KEY = 'premium_banner_dismissed_v2';
 
 export const Route = createFileRoute('/')({
   head: () => ({
@@ -84,9 +84,10 @@ function HomePage() {
           >
             ✕
           </button>
-          <p className="font-semibold text-amber-400">✨ Premium Card Backs are here</p>
-          <p className="mt-0.5 text-gray-300">
-            Upload any image as your card back for $5 — lifetime access.
+          <p className="font-semibold text-amber-400">💎 Go Premium</p>
+          <p className="mt-0.5 text-gray-300">Custom card backs, No Hands mode, and more (hopefully).</p>
+          <p className="mt-1 text-gray-300">
+            Use <span className="font-bold text-amber-400">HOTDOG</span> for 50% off
           </p>
           <p className="mt-1">
             {user ? (

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -145,6 +145,7 @@ export type Database = {
           created_at: string;
           id: string;
           is_premium: boolean;
+          no_hands_preset: Json | null;
           updated_at: string;
           username: string;
         };
@@ -156,6 +157,7 @@ export type Database = {
           created_at?: string;
           id: string;
           is_premium?: boolean;
+          no_hands_preset?: Json | null;
           updated_at?: string;
           username: string;
         };
@@ -167,6 +169,7 @@ export type Database = {
           created_at?: string;
           id?: string;
           is_premium?: boolean;
+          no_hands_preset?: Json | null;
           updated_at?: string;
           username?: string;
         };

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -67,8 +67,8 @@ Deno.serve(async (req) => {
           price_data: {
             currency: 'usd',
             product_data: {
-              name: 'Ride The Bus — Lifetime Premium',
-              description: 'Upload a custom card back image for all your games',
+              name: 'Ride The Bus Lifetime Premium',
+              description: 'Custom card backs, No Hands mode, and more. One-time payment.',
             },
             unit_amount: 500, // $5.00
           },


### PR DESCRIPTION
## Summary

- New premium feature: **No Hands mode** — pre-select one guess per round as your Tried & True, then toggle it on and the game drives itself
- Auto-plays each round with a 1.2s pause between flips; 3s pause after a miss so you can drink; stops on a win so you restart manually
- Preset saved to a new `no_hands_preset` JSONB column on `profiles` (migration applied)
- Toggle state persisted to localStorage
- Premium upgrade banner updated: diamond emoji, No Hands mentioned, HOTDOG promo code (50% off, ends Apr 7), localStorage key bumped to v2 so previous dismissers see it

## Test plan

- [ ] Non-premium user: No Hands panel does not appear in game
- [ ] Premium user: panel appears, "Set up" opens modal
- [ ] Modal buttons match game colors (red/black for round 1 & suits, white for rounds 2-3)
- [ ] Saving Tried & True persists across page refresh
- [ ] Toggle on: game auto-plays, buttons hidden, "No Hands is driving..." shown
- [ ] Correct guess: next round fires after ~1.2s
- [ ] Incorrect guess: "Take a drink!" shown, new cards dealt after ~3s
- [ ] Win: loop stops, "Another Ride?" button appears
- [ ] Toggle off mid-game: buttons reappear, auto-play stops
- [ ] Premium banner shows for non-premium users who previously dismissed the old one
- [ ] HOTDOG promo code works at checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)