### PR TITLE
Party Bus: replace per-action DB writes with Supabase broadcast

### DIFF
--- a/src/components/PartyGame/PartyGame.tsx
+++ b/src/components/PartyGame/PartyGame.tsx
@@ -11,6 +11,8 @@ import {
   suits,
   Card as GameCard,
 } from '../Game/useGameState';
+import { Button } from '../ui/Button';
+import { Panel } from '../ui/Panel';
 
 type PartyGameProps = {
   roomId: string;
@@ -113,7 +115,7 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
   };
 
   const renderPlayerGame = (playerState: PlayerState) => (
-    <div className="mb-8 rounded-lg bg-gray-800 p-6">
+    <Panel className="mb-4">
       <h3 className="mb-4 text-xl font-bold">{playerState.nickname}&apos;s Game</h3>
       <div className="flex flex-wrap justify-center gap-5">
         {playerState.cards.map((card: GameCard, index: number) => (
@@ -130,7 +132,7 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
       )}
       <p className="mt-2 text-lg">Round: {playerState.currentRound}</p>
       <p className="mt-2 text-lg">Drinks taken: {playerState.timesRedrawn}</p>
-    </div>
+    </Panel>
   );
 
   const renderLeaderboard = () => {
@@ -159,14 +161,14 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
 
     return (
       <>
-        <div className="mt-12 rounded-lg bg-gray-800 p-8">
+        <Panel className="mt-12">
           <h2 className="mb-6 text-center text-3xl font-bold">🏆 Final Results 🏆</h2>
           <div className="space-y-4">
             {sortedPlayers.map((player, index) => (
               <div
                 key={player.nickname}
                 className={`flex items-center justify-between rounded-lg p-4 ${
-                  index === 0 ? 'bg-yellow-500/20' : 'bg-gray-700'
+                  index === 0 ? 'bg-yellow-500/20' : 'bg-surface-input'
                 }`}
               >
                 <div className="flex items-center gap-3">
@@ -184,7 +186,7 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
             🎉 {winner.nickname} wins with {winner.timesRedrawn}{' '}
             {winner.timesRedrawn === 1 ? 'redraw' : 'redraws'}! 🎉
           </p>
-        </div>
+        </Panel>
         {isCurrentPlayerWinner &&
           createPortal(
             <Confetti
@@ -227,12 +229,9 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
 
               {gameState.isGameOver && !gameState.hasWon && (
                 <div className="mt-8 flex">
-                  <button
-                    className="cursor-pointer rounded-lg bg-white px-4 py-2 text-lg font-bold text-black shadow-md active:translate-y-1"
-                    onClick={() => redrawCards(false)}
-                  >
+                  <Button variant="ghost" onClick={() => redrawCards(false)}>
                     Redraw Cards
-                  </button>
+                  </Button>
                 </div>
               )}
 

--- a/src/components/PartyGame/PartyGame.tsx
+++ b/src/components/PartyGame/PartyGame.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { Card } from '../Card/Card';
 import { usePartyGameState } from './usePartyGameState';
-import supabase from '../../utils/supabase';
 import Confetti from 'react-confetti';
 import { createPortal } from 'react-dom';
 import { useDocumentSize } from '../../helpers/hooks/useDocumentSize';
@@ -12,8 +11,6 @@ import {
   suits,
   Card as GameCard,
 } from '../Game/useGameState';
-import { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
-import type { Database } from '../../types/database.types';
 
 type PartyGameProps = {
   roomId: string;
@@ -29,87 +26,21 @@ type PlayerState = {
   timesRedrawn: number;
 };
 
-type RealtimePlayerPayload = RealtimePostgresChangesPayload<
-  Database['public']['Tables']['party_bus_players']['Row']
-> & {
-  new: Database['public']['Tables']['party_bus_players']['Row'];
-};
-
 export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
   const { width, height } = useDocumentSize();
   const {
     gameState,
     playersState,
-    dispatch,
     firstRound,
     secondRound,
     thirdRound,
     finalRound,
     redrawCards,
+    initializeGame,
   } = usePartyGameState(roomId, nickname);
 
   useEffect(() => {
-    const initializeGame = async () => {
-      try {
-        // 1. First fetch all players' states
-        const { data: players } = await supabase
-          .from('party_bus_players')
-          .select('*')
-          .eq('room_id', roomId);
-
-        if (players) {
-          // Update state for each player
-          players.forEach((player) => {
-            if (player.game_state && player.nickname !== nickname) {
-              dispatch({
-                type: 'UPDATE_PLAYER_STATE',
-                nickname: player.nickname,
-                state: player.game_state as PlayerState,
-              });
-            }
-          });
-
-          // 2. Wait a bit to ensure player states are updated
-          await new Promise((resolve) => setTimeout(resolve, 100));
-
-          // 3. Draw initial cards using redrawCards (which handles state sync properly)
-          await redrawCards(false, true);
-        }
-      } catch (error) {
-        console.error('Error initializing game:', error);
-      }
-    };
-
-    // Initialize the game
     initializeGame();
-
-    // Subscribe to room updates
-    const channel = supabase
-      .channel(`room:${roomId}`)
-      .on<RealtimePlayerPayload>(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'party_bus_players',
-          filter: `room_id=eq.${roomId}`,
-        },
-        (payload: RealtimePlayerPayload) => {
-          if (payload.new.game_state && payload.new.nickname !== nickname) {
-            const state = payload.new.game_state as PlayerState;
-            dispatch({
-              type: 'UPDATE_PLAYER_STATE',
-              nickname: payload.new.nickname,
-              state,
-            });
-          }
-        },
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(channel);
-    };
   }, []);
 
   const renderButtons = () => {
@@ -203,7 +134,6 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
   );
 
   const renderLeaderboard = () => {
-    // Get all players including current player
     const allPlayers = [
       {
         nickname,
@@ -219,12 +149,10 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
       })),
     ];
 
-    // Check if all players have finished successfully
     const allFinished = allPlayers.every((player) => player.isGameOver && player.hasWon);
 
     if (!allFinished) return null;
 
-    // Sort players by score (times redrawn)
     const sortedPlayers = allPlayers.sort((a, b) => a.timesRedrawn - b.timesRedrawn);
     const winner = sortedPlayers[0];
     const isCurrentPlayerWinner = winner.nickname === nickname;
@@ -270,7 +198,6 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
     );
   };
 
-  // Check if all players have finished successfully
   const allPlayers = [
     { isGameOver: gameState.isGameOver, hasWon: gameState.hasWon },
     ...Object.values(playersState).map((state) => ({

--- a/src/components/PartyGame/PartyGame.tsx
+++ b/src/components/PartyGame/PartyGame.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Card } from '../Card/Card';
 import { usePartyGameState } from './usePartyGameState';
 import Confetti from 'react-confetti';
@@ -38,12 +37,7 @@ export const PartyGame = ({ roomId, nickname }: PartyGameProps) => {
     thirdRound,
     finalRound,
     redrawCards,
-    initializeGame,
   } = usePartyGameState(roomId, nickname);
-
-  useEffect(() => {
-    initializeGame();
-  }, []);
 
   const renderButtons = () => {
     switch (gameState.currentRound) {

--- a/src/components/PartyGame/partyGameReducer.test.ts
+++ b/src/components/PartyGame/partyGameReducer.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { partyGameReducer } from './usePartyGameState';
+import type { PartyGameReducerState } from './usePartyGameState';
+import type { Card } from '../Game/useGameState';
+
+const card = (suit: Card['suit'], numericValue: number): Card => ({
+  suit,
+  values: { rank: String(numericValue), numericValue },
+  showCardBack: true,
+});
+
+const HEARTS_5 = card('HEARTS', 5);
+const CLUBS_8 = card('CLUBS', 8);
+const DIAMONDS_3 = card('DIAMONDS', 3);
+const SPADES_K = card('SPADES', 13);
+
+const baseState: PartyGameReducerState = {
+  gameState: {
+    cards: [HEARTS_5, CLUBS_8, DIAMONDS_3, SPADES_K],
+    currentRound: 2,
+    hasWon: false,
+    isGameOver: false,
+    timesRedrawn: 1,
+  },
+  playersState: {},
+};
+
+// ─── DRAW_CARDS ──────────────────────────────────────────────────────────────
+
+describe('partyGameReducer — DRAW_CARDS', () => {
+  const newCards = [card('SPADES', 2), card('HEARTS', 7), card('CLUBS', 10), card('DIAMONDS', 9)];
+
+  it('uses the provided cards exactly (does not re-generate)', () => {
+    const next = partyGameReducer(baseState, { type: 'DRAW_CARDS', cards: newCards, resetScore: false });
+    expect(next.gameState.cards).toStrictEqual(newCards);
+  });
+
+  it('resets currentRound to 1', () => {
+    const next = partyGameReducer(baseState, { type: 'DRAW_CARDS', cards: newCards, resetScore: false });
+    expect(next.gameState.currentRound).toBe(1);
+  });
+
+  it('clears hasWon', () => {
+    const won = { ...baseState, gameState: { ...baseState.gameState, hasWon: true } };
+    const next = partyGameReducer(won, { type: 'DRAW_CARDS', cards: newCards, resetScore: false });
+    expect(next.gameState.hasWon).toBe(false);
+  });
+
+  it('clears isGameOver', () => {
+    const over = { ...baseState, gameState: { ...baseState.gameState, isGameOver: true } };
+    const next = partyGameReducer(over, { type: 'DRAW_CARDS', cards: newCards, resetScore: false });
+    expect(next.gameState.isGameOver).toBe(false);
+  });
+
+  it('increments timesRedrawn by 1 when resetScore is false', () => {
+    const next = partyGameReducer(baseState, { type: 'DRAW_CARDS', cards: newCards, resetScore: false });
+    expect(next.gameState.timesRedrawn).toBe(2);
+  });
+
+  it('resets timesRedrawn to 0 when resetScore is true', () => {
+    const next = partyGameReducer(baseState, { type: 'DRAW_CARDS', cards: newCards, resetScore: true });
+    expect(next.gameState.timesRedrawn).toBe(0);
+  });
+
+  it('does not modify playersState', () => {
+    const withPlayers = {
+      ...baseState,
+      playersState: {
+        Bob: { nickname: 'Bob', cards: [], currentRound: 1, hasWon: false, isGameOver: false, timesRedrawn: 0 },
+      },
+    };
+    const next = partyGameReducer(withPlayers, { type: 'DRAW_CARDS', cards: newCards, resetScore: false });
+    expect(next.playersState).toStrictEqual(withPlayers.playersState);
+  });
+});
+
+// ─── ADVANCE_ROUND ───────────────────────────────────────────────────────────
+
+describe('partyGameReducer — ADVANCE_ROUND', () => {
+  it('increments currentRound by 1', () => {
+    const next = partyGameReducer(baseState, { type: 'ADVANCE_ROUND', cardToFlip: 0 });
+    expect(next.gameState.currentRound).toBe(3);
+  });
+
+  it('flips the specified card face-up', () => {
+    const next = partyGameReducer(baseState, { type: 'ADVANCE_ROUND', cardToFlip: 1 });
+    expect(next.gameState.cards[1].showCardBack).toBe(false);
+  });
+
+  it('leaves all other cards face-down', () => {
+    const next = partyGameReducer(baseState, { type: 'ADVANCE_ROUND', cardToFlip: 1 });
+    expect(next.gameState.cards[0].showCardBack).toBe(true);
+    expect(next.gameState.cards[2].showCardBack).toBe(true);
+    expect(next.gameState.cards[3].showCardBack).toBe(true);
+  });
+
+  it('does not set isGameOver', () => {
+    const next = partyGameReducer(baseState, { type: 'ADVANCE_ROUND', cardToFlip: 0 });
+    expect(next.gameState.isGameOver).toBe(false);
+  });
+});
+
+// ─── GAME_OVER ────────────────────────────────────────────────────────────────
+
+describe('partyGameReducer — GAME_OVER', () => {
+  it('sets isGameOver to true', () => {
+    const next = partyGameReducer(baseState, { type: 'GAME_OVER', cardToFlip: 0 });
+    expect(next.gameState.isGameOver).toBe(true);
+  });
+
+  it('sets hasWon to false', () => {
+    const next = partyGameReducer(baseState, { type: 'GAME_OVER', cardToFlip: 0 });
+    expect(next.gameState.hasWon).toBe(false);
+  });
+
+  it('flips the specified card face-up', () => {
+    const next = partyGameReducer(baseState, { type: 'GAME_OVER', cardToFlip: 2 });
+    expect(next.gameState.cards[2].showCardBack).toBe(false);
+  });
+
+  it('leaves all other cards face-down', () => {
+    const next = partyGameReducer(baseState, { type: 'GAME_OVER', cardToFlip: 2 });
+    expect(next.gameState.cards[0].showCardBack).toBe(true);
+    expect(next.gameState.cards[1].showCardBack).toBe(true);
+    expect(next.gameState.cards[3].showCardBack).toBe(true);
+  });
+
+  it('does not change currentRound', () => {
+    const next = partyGameReducer(baseState, { type: 'GAME_OVER', cardToFlip: 0 });
+    expect(next.gameState.currentRound).toBe(baseState.gameState.currentRound);
+  });
+});
+
+// ─── WIN_GAME ─────────────────────────────────────────────────────────────────
+
+describe('partyGameReducer — WIN_GAME', () => {
+  it('sets hasWon to true', () => {
+    const next = partyGameReducer(baseState, { type: 'WIN_GAME' });
+    expect(next.gameState.hasWon).toBe(true);
+  });
+
+  it('sets isGameOver to true', () => {
+    const next = partyGameReducer(baseState, { type: 'WIN_GAME' });
+    expect(next.gameState.isGameOver).toBe(true);
+  });
+
+  it('flips all cards face-up', () => {
+    const next = partyGameReducer(baseState, { type: 'WIN_GAME' });
+    expect(next.gameState.cards.every((c) => c.showCardBack === false)).toBe(true);
+  });
+});
+
+// ─── UPDATE_PLAYER_STATE ─────────────────────────────────────────────────────
+
+describe('partyGameReducer — UPDATE_PLAYER_STATE', () => {
+  const bobState = {
+    nickname: 'Bob',
+    cards: [card('CLUBS', 3)],
+    currentRound: 3,
+    hasWon: false,
+    isGameOver: false,
+    timesRedrawn: 2,
+  };
+
+  it('adds a new player to playersState', () => {
+    const next = partyGameReducer(baseState, {
+      type: 'UPDATE_PLAYER_STATE',
+      nickname: 'Bob',
+      state: bobState,
+    });
+    expect(next.playersState['Bob']).toStrictEqual(bobState);
+  });
+
+  it('overwrites an existing player entry', () => {
+    const withBob = {
+      ...baseState,
+      playersState: { Bob: { ...bobState, currentRound: 1 } },
+    };
+    const next = partyGameReducer(withBob, {
+      type: 'UPDATE_PLAYER_STATE',
+      nickname: 'Bob',
+      state: bobState,
+    });
+    expect(next.playersState['Bob'].currentRound).toBe(3);
+  });
+
+  it('does not affect other players already in playersState', () => {
+    const alice = { nickname: 'Alice', cards: [], currentRound: 2, hasWon: false, isGameOver: false, timesRedrawn: 0 };
+    const withAlice = { ...baseState, playersState: { Alice: alice } };
+    const next = partyGameReducer(withAlice, {
+      type: 'UPDATE_PLAYER_STATE',
+      nickname: 'Bob',
+      state: bobState,
+    });
+    expect(next.playersState['Alice']).toStrictEqual(alice);
+  });
+
+  it('does not modify gameState', () => {
+    const next = partyGameReducer(baseState, {
+      type: 'UPDATE_PLAYER_STATE',
+      nickname: 'Bob',
+      state: bobState,
+    });
+    expect(next.gameState).toStrictEqual(baseState.gameState);
+  });
+});

--- a/src/components/PartyGame/usePartyGameState.test.ts
+++ b/src/components/PartyGame/usePartyGameState.test.ts
@@ -1,0 +1,369 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePartyGameState } from './usePartyGameState';
+import type { PlayerState } from './usePartyGameState';
+
+// ─── Supabase mock ────────────────────────────────────────────────────────────
+// vi.hoisted runs before vi.mock factories (both are hoisted), letting us share
+// mock objects across the factory boundary without the usual closure restrictions.
+
+const { mockSend, mockUpdate, mockChannelInstance, triggerBroadcast } = vi.hoisted(() => {
+  const mockSend = vi.fn().mockResolvedValue('ok');
+  const mockUpdate = vi.fn();
+
+  let capturedBroadcastCb: ((e: { payload: unknown }) => void) | null = null;
+
+  const mockChannelInstance = {
+    on: vi.fn().mockImplementation(function (
+      this: object,
+      _type: string,
+      _event: object,
+      cb: (e: { payload: unknown }) => void,
+    ) {
+      capturedBroadcastCb = cb;
+      return this;
+    }),
+    subscribe: vi.fn().mockImplementation(function (this: object) {
+      return this;
+    }),
+    send: mockSend,
+  };
+
+  // Builds a chainable Supabase query builder that resolves to { data, error }.
+  const makeBuilder = (data: unknown = null) => {
+    type Builder = {
+      select: ReturnType<typeof vi.fn>;
+      eq: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+      then: (resolve: (v: { data: unknown; error: null }) => unknown, reject?: (e: unknown) => unknown) => Promise<unknown>;
+      catch: (reject: (e: unknown) => unknown) => Promise<unknown>;
+      finally: (cb: () => void) => Promise<unknown>;
+    };
+    const b: Builder = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      update: vi.fn(),
+      then: (resolve, reject) => Promise.resolve({ data, error: null }).then(resolve, reject),
+      catch: (reject) => Promise.resolve({ data, error: null }).catch(reject),
+      finally: (cb) => Promise.resolve({ data, error: null }).finally(cb),
+    };
+    b.select.mockReturnValue(b);
+    b.eq.mockReturnValue(b);
+    b.update.mockImplementation(() => {
+      mockUpdate();
+      return b;
+    });
+    return b;
+  };
+
+  return {
+    mockSend,
+    mockUpdate,
+    mockChannelInstance,
+    triggerBroadcast: (payload: unknown) => capturedBroadcastCb?.({ payload }),
+    makeBuilder,
+  };
+});
+
+vi.mock('../../utils/supabase', () => ({
+  default: {
+    channel: vi.fn(() => mockChannelInstance),
+    removeChannel: vi.fn(),
+    from: vi.fn(() => {
+      const b = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        update: vi.fn(),
+        then: (resolve: (v: { data: unknown; error: null }) => unknown, reject?: (e: unknown) => unknown) =>
+          Promise.resolve({ data: [], error: null }).then(resolve, reject),
+        catch: (reject: (e: unknown) => unknown) =>
+          Promise.resolve({ data: [], error: null }).catch(reject),
+        finally: (cb: () => void) =>
+          Promise.resolve({ data: [], error: null }).finally(cb),
+      };
+      b.select.mockReturnValue(b);
+      b.eq.mockReturnValue(b);
+      b.update.mockImplementation(() => {
+        mockUpdate();
+        return b;
+      });
+      return b;
+    }),
+  },
+}));
+
+// Import after vi.mock so we get the mocked version
+import supabase from '../../utils/supabase';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ROOM_ID = 'room-abc';
+const NICKNAME = 'Alice';
+
+const bobState: PlayerState = {
+  nickname: 'Bob',
+  cards: [{ suit: 'CLUBS', values: { rank: '5', numericValue: 5 }, showCardBack: false }],
+  currentRound: 2,
+  hasWon: false,
+  isGameOver: false,
+  timesRedrawn: 0,
+};
+
+// ─── Channel subscription ─────────────────────────────────────────────────────
+
+describe('broadcast subscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('subscribes to the party-game channel on mount', () => {
+    renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+    expect(vi.mocked(supabase).channel).toHaveBeenCalledWith(`party-game:${ROOM_ID}`);
+  });
+
+  it('adds other players to playersState when a broadcast arrives', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      triggerBroadcast({ nickname: 'Bob', newState: bobState });
+    });
+
+    expect(result.current.playersState['Bob']).toStrictEqual(bobState);
+  });
+
+  it('ignores broadcast events from the local player', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      triggerBroadcast({ nickname: NICKNAME, newState: bobState });
+    });
+
+    expect(result.current.playersState[NICKNAME]).toBeUndefined();
+  });
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+    unmount();
+    expect(vi.mocked(supabase).removeChannel).toHaveBeenCalledWith(mockChannelInstance);
+  });
+});
+
+// ─── redrawCards ──────────────────────────────────────────────────────────────
+
+describe('redrawCards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('always broadcasts the new state', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false);
+    });
+
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'broadcast', event: 'player_action' }),
+    );
+  });
+
+  it('always writes to the DB as a checkpoint', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false);
+    });
+
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('increments timesRedrawn when not initial draw', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, false);
+    });
+
+    expect(result.current.gameState.timesRedrawn).toBe(1);
+  });
+
+  it('keeps timesRedrawn at 0 for initial draw', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    expect(result.current.gameState.timesRedrawn).toBe(0);
+  });
+
+  it('draws exactly 4 cards', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    expect(result.current.gameState.cards).toHaveLength(4);
+  });
+
+  it('all drawn cards start face-down', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    expect(result.current.gameState.cards.every((c) => c.showCardBack === true)).toBe(true);
+  });
+});
+
+// ─── firstRound ───────────────────────────────────────────────────────────────
+
+describe('firstRound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('advances round and only broadcasts (no DB write) on a correct guess', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const firstCard = result.current.gameState.cards[0];
+    const isRed = firstCard.suit === 'HEARTS' || firstCard.suit === 'DIAMONDS';
+    const correctGuess = isRed ? 'red' : 'black';
+
+    const sendCallsBefore = mockSend.mock.calls.length;
+    const updateCallsBefore = mockUpdate.mock.calls.length;
+
+    await act(async () => {
+      await result.current.firstRound(correctGuess);
+    });
+
+    expect(mockSend.mock.calls.length).toBe(sendCallsBefore + 1);
+    expect(mockUpdate.mock.calls.length).toBe(updateCallsBefore); // no DB write
+    expect(result.current.gameState.currentRound).toBe(2);
+    expect(result.current.gameState.isGameOver).toBe(false);
+  });
+
+  it('sets game over and writes to DB on a wrong guess', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const firstCard = result.current.gameState.cards[0];
+    const isRed = firstCard.suit === 'HEARTS' || firstCard.suit === 'DIAMONDS';
+    const wrongGuess = isRed ? 'black' : 'red';
+
+    const updateCallsBefore = mockUpdate.mock.calls.length;
+
+    await act(async () => {
+      await result.current.firstRound(wrongGuess);
+    });
+
+    expect(result.current.gameState.isGameOver).toBe(true);
+    expect(result.current.gameState.hasWon).toBe(false);
+    expect(mockUpdate.mock.calls.length).toBeGreaterThan(updateCallsBefore);
+  });
+});
+
+// ─── finalRound ───────────────────────────────────────────────────────────────
+
+describe('finalRound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets hasWon and writes to DB on a correct suit guess', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const fourthCard = result.current.gameState.cards[3];
+    const updateCallsBefore = mockUpdate.mock.calls.length;
+
+    await act(async () => {
+      await result.current.finalRound(fourthCard.suit);
+    });
+
+    expect(result.current.gameState.hasWon).toBe(true);
+    expect(result.current.gameState.isGameOver).toBe(true);
+    expect(mockUpdate.mock.calls.length).toBeGreaterThan(updateCallsBefore);
+  });
+
+  it('sets game over without win and writes to DB on a wrong suit guess', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const fourthCard = result.current.gameState.cards[3];
+    const wrongSuit = (['HEARTS', 'DIAMONDS', 'CLUBS', 'SPADES'] as const).find(
+      (s) => s !== fourthCard.suit,
+    )!;
+    const updateCallsBefore = mockUpdate.mock.calls.length;
+
+    await act(async () => {
+      await result.current.finalRound(wrongSuit);
+    });
+
+    expect(result.current.gameState.hasWon).toBe(false);
+    expect(result.current.gameState.isGameOver).toBe(true);
+    expect(mockUpdate.mock.calls.length).toBeGreaterThan(updateCallsBefore);
+  });
+
+  it('flips all cards face-up on a win', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const fourthCard = result.current.gameState.cards[3];
+
+    await act(async () => {
+      await result.current.finalRound(fourthCard.suit);
+    });
+
+    expect(result.current.gameState.cards.every((c) => c.showCardBack === false)).toBe(true);
+  });
+});
+
+// ─── Broadcast payload shape ──────────────────────────────────────────────────
+
+describe('broadcast payload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('includes the local nickname in every broadcast', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const sentPayload = mockSend.mock.calls[0]?.[0];
+    expect(sentPayload?.payload?.nickname).toBe(NICKNAME);
+  });
+
+  it('broadcast newState cards match local gameState after a draw', async () => {
+    const { result } = renderHook(() => usePartyGameState(ROOM_ID, NICKNAME));
+
+    await act(async () => {
+      await result.current.redrawCards(false, true);
+    });
+
+    const sentPayload = mockSend.mock.calls[0]?.[0];
+    expect(sentPayload?.payload?.newState?.cards).toStrictEqual(result.current.gameState.cards);
+  });
+});

--- a/src/components/PartyGame/usePartyGameState.ts
+++ b/src/components/PartyGame/usePartyGameState.ts
@@ -122,7 +122,13 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
 
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
 
+  // Ref so the subscribe callback always calls the latest initializeGame
+  // without needing to re-create the channel when the function reference changes.
+  const initializeGameRef = useRef<(() => Promise<void>) | null>(null);
+
   useEffect(() => {
+    let initialized = false;
+
     const channel = supabase
       .channel(`party-game:${roomId}`)
       .on('broadcast', { event: 'player_action' }, ({ payload }) => {
@@ -134,7 +140,14 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
           dispatch({ type: 'UPDATE_PLAYER_STATE', nickname: sender, state: newState });
         }
       })
-      .subscribe();
+      .subscribe(async (status) => {
+        // Wait for the channel to be fully subscribed before drawing and
+        // broadcasting the initial hand — send() is a no-op before this point.
+        if (status === 'SUBSCRIBED' && !initialized) {
+          initialized = true;
+          await initializeGameRef.current?.();
+        }
+      });
 
     channelRef.current = channel;
 
@@ -201,6 +214,9 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
 
     await redrawCards(false, true);
   };
+
+  // Keep the ref current so the subscribe callback always calls the latest closure.
+  initializeGameRef.current = initializeGame;
 
   const firstRound = async (color: RedOrBlack) => {
     const current = gameStateRef.current;
@@ -311,6 +327,5 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
     thirdRound,
     finalRound,
     redrawCards,
-    initializeGame,
   };
 };

--- a/src/components/PartyGame/usePartyGameState.ts
+++ b/src/components/PartyGame/usePartyGameState.ts
@@ -1,4 +1,4 @@
-import { useReducer } from 'react';
+import { useReducer, useEffect, useRef } from 'react';
 import {
   Card,
   RedOrBlack,
@@ -8,7 +8,7 @@ import {
 } from '../Game/useGameState';
 import supabase from '../../utils/supabase';
 
-type PlayerState = {
+export type PlayerState = {
   nickname: string;
   cards: Card[];
   currentRound: number;
@@ -17,7 +17,7 @@ type PlayerState = {
   timesRedrawn: number;
 };
 
-type PartyGameState = {
+export type PartyGameState = {
   cards: Card[];
   currentRound: number;
   hasWon: boolean;
@@ -25,30 +25,30 @@ type PartyGameState = {
   timesRedrawn: number;
 };
 
-type PlayersState = {
+export type PlayersState = {
   [nickname: string]: PlayerState;
 };
 
-type PartyGameAction =
-  | { type: 'DRAW_CARDS'; amountToDraw: number; resetScore: boolean }
+export type PartyGameAction =
+  | { type: 'DRAW_CARDS'; cards: Card[]; resetScore: boolean }
   | { type: 'ADVANCE_ROUND'; cardToFlip: number }
   | { type: 'GAME_OVER'; cardToFlip: number }
   | { type: 'WIN_GAME' }
   | { type: 'UPDATE_PLAYER_STATE'; nickname: string; state: PlayerState };
 
-type ReducerState = {
+export type PartyGameReducerState = {
   gameState: PartyGameState;
   playersState: PlayersState;
 };
 
-const reducer = (state: ReducerState, action: PartyGameAction): ReducerState => {
+export const partyGameReducer = (state: PartyGameReducerState, action: PartyGameAction): PartyGameReducerState => {
   switch (action.type) {
     case 'DRAW_CARDS':
       return {
         ...state,
         gameState: {
           ...state.gameState,
-          cards: drawCards(action.amountToDraw),
+          cards: action.cards,
           hasWon: false,
           isGameOver: false,
           currentRound: 1,
@@ -105,7 +105,7 @@ const reducer = (state: ReducerState, action: PartyGameAction): ReducerState => 
 };
 
 export const usePartyGameState = (roomId: string, nickname: string) => {
-  const [{ gameState, playersState }, dispatch] = useReducer(reducer, {
+  const [{ gameState, playersState }, dispatch] = useReducer(partyGameReducer, {
     gameState: {
       cards: [],
       currentRound: 1,
@@ -116,90 +116,116 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
     playersState: {},
   });
 
-  const syncGameState = async (newState: PartyGameState, action: PartyGameAction) => {
-    try {
-      // Update local state first
-      dispatch(action);
+  // Ref so async callbacks always read the latest state without stale closures
+  const gameStateRef = useRef(gameState);
+  gameStateRef.current = gameState;
 
-      // Then update remote state
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`party-game:${roomId}`)
+      .on('broadcast', { event: 'player_action' }, ({ payload }) => {
+        const { nickname: sender, newState } = payload as {
+          nickname: string;
+          newState: PlayerState;
+        };
+        if (sender !== nickname) {
+          dispatch({ type: 'UPDATE_PLAYER_STATE', nickname: sender, state: newState });
+        }
+      })
+      .subscribe();
+
+    channelRef.current = channel;
+
+    return () => {
+      supabase.removeChannel(channel);
+      channelRef.current = null;
+    };
+  }, [roomId, nickname]);
+
+  // Broadcast current state to all players in the room.
+  // isCheckpoint=true also writes to DB so reconnecting players can recover.
+  const broadcastAndSync = async (newState: PartyGameState, isCheckpoint: boolean) => {
+    const fullState: PlayerState = { nickname, ...newState };
+
+    await channelRef.current?.send({
+      type: 'broadcast',
+      event: 'player_action',
+      payload: { nickname, newState: fullState },
+    });
+
+    if (isCheckpoint) {
       await supabase
         .from('party_bus_players')
-        .update({
-          game_state: {
-            nickname,
-            ...newState,
-          },
-        })
+        .update({ game_state: fullState })
         .eq('room_id', roomId)
         .eq('nickname', nickname);
-    } catch (error) {
-      console.error('Error syncing game state:', error);
     }
   };
 
   const redrawCards = async (hasWon: boolean, isInitialDraw: boolean = false) => {
-    // Draw new cards first
     const newCards = drawCards(4);
+    const current = gameStateRef.current;
+    const timesRedrawn = isInitialDraw ? 0 : hasWon ? 0 : current.timesRedrawn + 1;
 
-    // Create the new state
-    const newState = {
+    const newState: PartyGameState = {
       cards: newCards,
       currentRound: 1,
       hasWon: false,
       isGameOver: false,
-      timesRedrawn: isInitialDraw ? 0 : hasWon ? 0 : gameState.timesRedrawn + 1,
+      timesRedrawn,
     };
 
-    try {
-      // Update local state first
-      dispatch({
-        type: 'DRAW_CARDS',
-        amountToDraw: 4,
-        resetScore: hasWon || isInitialDraw,
+    dispatch({ type: 'DRAW_CARDS', cards: newCards, resetScore: hasWon || isInitialDraw });
+    await broadcastAndSync(newState, true);
+  };
+
+  const initializeGame = async () => {
+    const { data: players } = await supabase
+      .from('party_bus_players')
+      .select('*')
+      .eq('room_id', roomId);
+
+    if (players) {
+      players.forEach((player) => {
+        if (player.game_state && player.nickname !== nickname) {
+          dispatch({
+            type: 'UPDATE_PLAYER_STATE',
+            nickname: player.nickname,
+            state: player.game_state as PlayerState,
+          });
+        }
       });
-
-      // Wait a bit for state to update
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Then sync to Supabase with the complete state
-      await supabase
-        .from('party_bus_players')
-        .update({
-          game_state: {
-            nickname,
-            ...newState,
-            cards: newCards, // Use the new cards directly to ensure they're included
-          },
-        })
-        .eq('room_id', roomId)
-        .eq('nickname', nickname);
-    } catch (error) {
-      console.error('Error redrawing cards:', error);
     }
+
+    await redrawCards(false, true);
   };
 
   const firstRound = async (color: RedOrBlack) => {
-    const card = gameState.cards[0];
+    const current = gameStateRef.current;
+    const card = current.cards[0];
     const isRed = card.suit === 'HEARTS' || card.suit === 'DIAMONDS';
     const isCorrect = isRed === (color === 'red');
 
-    const newState = {
-      ...gameState,
-      currentRound: isCorrect ? gameState.currentRound + 1 : gameState.currentRound,
+    const newState: PartyGameState = {
+      ...current,
+      currentRound: isCorrect ? current.currentRound + 1 : current.currentRound,
       isGameOver: !isCorrect,
       hasWon: false,
-      cards: gameState.cards.map((c, index) => (index === 0 ? { ...c, showCardBack: false } : c)),
+      cards: current.cards.map((c, i) => (i === 0 ? { ...c, showCardBack: false } : c)),
     };
 
-    await syncGameState(
-      newState,
+    dispatch(
       isCorrect ? { type: 'ADVANCE_ROUND', cardToFlip: 0 } : { type: 'GAME_OVER', cardToFlip: 0 },
     );
+    await broadcastAndSync(newState, !isCorrect);
   };
 
   const secondRound = async (guess: HigherLowerOrSame) => {
-    const firstCard = gameState.cards[0];
-    const secondCard = gameState.cards[1];
+    const current = gameStateRef.current;
+    const firstCard = current.cards[0];
+    const secondCard = current.cards[1];
 
     const isHigher = secondCard.values.numericValue > firstCard.values.numericValue;
     const isLower = secondCard.values.numericValue < firstCard.values.numericValue;
@@ -208,24 +234,25 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
       (isLower && guess === 'lower') ||
       (firstCard.values.numericValue === secondCard.values.numericValue && guess === 'same');
 
-    const newState = {
-      ...gameState,
-      currentRound: isCorrect ? gameState.currentRound + 1 : gameState.currentRound,
+    const newState: PartyGameState = {
+      ...current,
+      currentRound: isCorrect ? current.currentRound + 1 : current.currentRound,
       isGameOver: !isCorrect,
       hasWon: false,
-      cards: gameState.cards.map((c, index) => (index === 1 ? { ...c, showCardBack: false } : c)),
+      cards: current.cards.map((c, i) => (i === 1 ? { ...c, showCardBack: false } : c)),
     };
 
-    await syncGameState(
-      newState,
+    dispatch(
       isCorrect ? { type: 'ADVANCE_ROUND', cardToFlip: 1 } : { type: 'GAME_OVER', cardToFlip: 1 },
     );
+    await broadcastAndSync(newState, !isCorrect);
   };
 
   const thirdRound = async (guess: InsideOutsideOrSame) => {
-    const firstCard = gameState.cards[0];
-    const secondCard = gameState.cards[1];
-    const thirdCard = gameState.cards[2];
+    const current = gameStateRef.current;
+    const firstCard = current.cards[0];
+    const secondCard = current.cards[1];
+    const thirdCard = current.cards[2];
 
     const firstValue = firstCard.values.numericValue;
     const secondValue = secondCard.values.numericValue;
@@ -243,37 +270,36 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
       (isOutside && guess === 'outside') ||
       (isSame && guess === 'same');
 
-    const newState = {
-      ...gameState,
-      currentRound: isCorrect ? gameState.currentRound + 1 : gameState.currentRound,
+    const newState: PartyGameState = {
+      ...current,
+      currentRound: isCorrect ? current.currentRound + 1 : current.currentRound,
       isGameOver: !isCorrect,
       hasWon: false,
-      cards: gameState.cards.map((c, index) => (index === 2 ? { ...c, showCardBack: false } : c)),
+      cards: current.cards.map((c, i) => (i === 2 ? { ...c, showCardBack: false } : c)),
     };
 
-    await syncGameState(
-      newState,
+    dispatch(
       isCorrect ? { type: 'ADVANCE_ROUND', cardToFlip: 2 } : { type: 'GAME_OVER', cardToFlip: 2 },
     );
+    await broadcastAndSync(newState, !isCorrect);
   };
 
   const finalRound = async (suit: string) => {
-    const card = gameState.cards[3];
+    const current = gameStateRef.current;
+    const card = current.cards[3];
     const isCorrect = card.suit === suit;
 
-    const newState = {
-      ...gameState,
+    const newState: PartyGameState = {
+      ...current,
       isGameOver: true,
       hasWon: isCorrect,
-      cards: gameState.cards.map((c, index) =>
-        index === 3 || isCorrect ? { ...c, showCardBack: false } : c,
+      cards: current.cards.map((c, i) =>
+        i === 3 || isCorrect ? { ...c, showCardBack: false } : c,
       ),
     };
 
-    await syncGameState(
-      newState,
-      isCorrect ? { type: 'WIN_GAME' } : { type: 'GAME_OVER', cardToFlip: 3 },
-    );
+    dispatch(isCorrect ? { type: 'WIN_GAME' } : { type: 'GAME_OVER', cardToFlip: 3 });
+    await broadcastAndSync(newState, true);
   };
 
   return {
@@ -285,5 +311,6 @@ export const usePartyGameState = (roomId: string, nickname: string) => {
     thirdRound,
     finalRound,
     redrawCards,
+    initializeGame,
   };
 };

--- a/src/components/RoomLink/RoomLink.tsx
+++ b/src/components/RoomLink/RoomLink.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import { Button } from '../ui/Button';
+import { Panel } from '../ui/Panel';
 
 type RoomLinkProps = {
   roomId: string;
@@ -23,25 +25,22 @@ export const RoomLink = ({ roomId }: RoomLinkProps) => {
   };
 
   return (
-    <div className="flex flex-col items-center gap-4 rounded-lg bg-gray-800 p-4">
+    <Panel className="flex flex-col items-center gap-4">
       <h3 className="text-xl font-bold">Room Code: {roomId}</h3>
       <div className="flex items-center gap-2">
         <input
           type="text"
           value={roomUrl}
           readOnly
-          className="w-64 rounded-lg bg-gray-700 px-4 py-2 text-white sm:w-96"
+          className="w-64 rounded-lg bg-surface-input px-4 py-2 text-white sm:w-96"
         />
-        <button
-          onClick={copyToClipboard}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
-        >
+        <Button variant="ghost" onClick={copyToClipboard}>
           {copied ? '✓ Copied!' : 'Copy Link'}
-        </button>
+        </Button>
       </div>
       <p className="text-sm text-gray-400">
         Share this link with your friends to invite them to the game!
       </p>
-    </div>
+    </Panel>
   );
 };

--- a/src/pages/PartyBus.tsx
+++ b/src/pages/PartyBus.tsx
@@ -80,7 +80,7 @@ const NicknameModal = ({ onSubmit, isJoining }: NicknameModalProps) => {
             disabled={isSubmitting}
           />
           {error && <p className="text-sm text-red-500">{error}</p>}
-          <Button variant="primary" className="w-full" onClick={handleSubmit} disabled={isSubmitting}>
+          <Button variant="secondary" className="w-full" onClick={handleSubmit} disabled={isSubmitting}>
             {isSubmitting ? 'Please wait...' : isJoining ? 'Join Game' : 'Create Room'}
           </Button>
         </div>
@@ -580,7 +580,7 @@ export const PartyBus = () => {
           </div>
 
           {isHost && (
-            <Button variant="primary" onClick={startGame}>
+            <Button variant="secondary" onClick={startGame}>
               Start Game
             </Button>
           )}

--- a/src/pages/PartyBus.tsx
+++ b/src/pages/PartyBus.tsx
@@ -91,16 +91,39 @@ const NicknameModal = ({ onSubmit, isJoining }: NicknameModalProps) => {
   );
 };
 
+// Persists host credentials across the navigate() that switches route files,
+// which would otherwise unmount the component and reset all state.
+const HOST_SESSION_KEY = 'party-bus-host-session';
+
+type HostSession = { nickname: string; roomId: string };
+
+const consumeHostSession = (): HostSession | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(HOST_SESSION_KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(HOST_SESSION_KEY);
+    return JSON.parse(raw) as HostSession;
+  } catch {
+    return null;
+  }
+};
+
 export const PartyBus = () => {
   const navigate = useNavigate();
   const { roomCode } = useParams({ strict: false }) as { roomCode?: string };
-  const [isHost, setIsHost] = useState(false);
-  const [nickname, setNickname] = useState<string | null>(null);
-  const [showNicknamePrompt, setShowNicknamePrompt] = useState(true);
+
+  // consumeHostSession() is called once on mount via the lazy initializer.
+  // If the host just created a room and was navigated here, it returns their
+  // credentials so we can skip the nickname prompt entirely.
+  const [hostSession] = useState<HostSession | null>(consumeHostSession);
+  const [isHost, setIsHost] = useState(!!hostSession);
+  const [nickname, setNickname] = useState<string | null>(hostSession?.nickname ?? null);
+  const [showNicknamePrompt, setShowNicknamePrompt] = useState(!hostSession);
   const [gameStarted, setGameStarted] = useState(false);
   const [players, setPlayers] = useState<Player[]>([]);
   const [error, setError] = useState('');
-  const [roomId, setRoomId] = useState<string | null>(null);
+  const [roomId, setRoomId] = useState<string | null>(hostSession?.roomId ?? null);
   const [showDancingUzbek, setShowDancingUzbek] = useState(false);
 
   // Track konami code progress
@@ -476,10 +499,12 @@ export const PartyBus = () => {
           return 'Failed to create room. Please try again.';
         }
 
-        setNickname(name);
-        setIsHost(true);
-        setShowNicknamePrompt(false);
-        setRoomId(room.id);
+        // Write session before navigating — the navigate() switches route files,
+        // unmounting this component. consumeHostSession() picks this up on remount.
+        sessionStorage.setItem(
+          HOST_SESSION_KEY,
+          JSON.stringify({ nickname: name, roomId: room.id } satisfies HostSession),
+        );
         navigate({ to: '/party-bus/$roomCode', params: { roomCode: newRoomCode } });
         return undefined;
       } catch (err) {

--- a/src/pages/PartyBus.tsx
+++ b/src/pages/PartyBus.tsx
@@ -6,6 +6,8 @@ import { generateRoomId } from '../utils/generateRoomId';
 import { RoomLink } from '../components/RoomLink/RoomLink';
 import { Database } from '../types/database.types.ts';
 import { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import { Button } from '../components/ui/Button';
+import { Panel } from '../components/ui/Panel';
 
 type NicknameModalProps = {
   onSubmit: (nickname: string) => Promise<string | undefined>;
@@ -54,18 +56,18 @@ const NicknameModal = ({ onSubmit, isJoining }: NicknameModalProps) => {
 
   return (
     <div className="bg-opacity-50 fixed inset-0 flex items-center justify-center bg-black">
-      <div className="w-96 rounded-lg bg-gray-800 p-6">
+      <Panel className="w-96">
         <h3 className="mb-4 text-xl font-bold">
           {isJoining ? 'Enter nickname to join' : 'Enter your nickname'}
         </h3>
-        <div className="flex flex-col gap-4 space-y-4">
+        <div className="flex flex-col gap-4">
           <input
             type="text"
-            className="w-full rounded-lg bg-gray-700 px-4 py-2 text-white"
+            className="w-full rounded-lg bg-surface-input px-4 py-2 text-white"
             value={nickname}
             onChange={(e) => {
               setNickname(e.target.value);
-              setError(''); // Clear error when user types
+              setError('');
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && nickname && !isSubmitting) {
@@ -78,15 +80,11 @@ const NicknameModal = ({ onSubmit, isJoining }: NicknameModalProps) => {
             disabled={isSubmitting}
           />
           {error && <p className="text-sm text-red-500">{error}</p>}
-          <button
-            className="w-full rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-            onClick={handleSubmit}
-            disabled={isSubmitting}
-          >
+          <Button variant="primary" className="w-full" onClick={handleSubmit} disabled={isSubmitting}>
             {isSubmitting ? 'Please wait...' : isJoining ? 'Join Game' : 'Create Room'}
-          </button>
+          </Button>
         </div>
-      </div>
+      </Panel>
     </div>
   );
 };
@@ -548,10 +546,10 @@ export const PartyBus = () => {
       )}
 
       {!showNicknamePrompt && !gameStarted && (
-        <div className="relative mt-8 rounded-lg bg-gray-800 p-6">
-          <div className="bg-opacity-20 mb-6 rounded-lg border border-yellow-500 bg-yellow-300 p-4">
-            <p className="mb-1 font-bold text-black">🚧 BETA WARNING! 🚧</p>
-            <p className="text-balance text-black">
+        <Panel className="relative mt-8">
+          <div className="mb-6 rounded-lg border border-yellow-500 bg-yellow-300/20 p-4">
+            <p className="mb-1 font-bold text-yellow-300">🚧 BETA WARNING! 🚧</p>
+            <p className="text-balance text-yellow-100">
               This feature is still in beta. If it breaks, it&apos;s your fault.
               <br />
               Have fun out there!
@@ -572,7 +570,7 @@ export const PartyBus = () => {
               {players.map((player) => (
                 <div
                   key={player.nickname}
-                  className="flex items-center justify-between rounded-lg bg-gray-700 p-3"
+                  className="flex items-center justify-between rounded-lg bg-surface-input p-3"
                 >
                   <span>{player.nickname}</span>
                   {player.nickname === nickname && <span className="text-green-400">(You)</span>}
@@ -582,25 +580,23 @@ export const PartyBus = () => {
           </div>
 
           {isHost && (
-            <button
-              className="cursor-pointer rounded-lg bg-purple-500 px-4 py-2 text-lg font-bold text-white shadow-md"
-              onClick={startGame}
-            >
+            <Button variant="primary" onClick={startGame}>
               Start Game
-            </button>
+            </Button>
           )}
 
           {/* Dancing Uzbek Man Easter Egg */}
           {showDancingUzbek && (
-            <div className="bg-opacity-80 absolute inset-0 z-10 flex items-center justify-center bg-black">
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-black/80">
               <div className="text-center">
                 <div className="mb-4 animate-bounce text-6xl">🕺</div>
                 <div className="animate-pulse text-2xl font-bold text-yellow-400">
                   VERY NICE! GREAT SUCCESS!
                 </div>
                 {isHost && (
-                  <button
-                    className="mt-4 rounded-lg bg-purple-500 px-4 py-2 text-white"
+                  <Button
+                    variant="ghost"
+                    className="mt-4"
                     onClick={async () => {
                       if (roomId) {
                         const update: Database['public']['Tables']['party_bus_rooms']['Update'] = {
@@ -611,12 +607,12 @@ export const PartyBus = () => {
                     }}
                   >
                     High Five! ✋
-                  </button>
+                  </Button>
                 )}
               </div>
             </div>
           )}
-        </div>
+        </Panel>
       )}
 
       {!showNicknamePrompt && gameStarted && roomId && nickname && (
@@ -624,7 +620,7 @@ export const PartyBus = () => {
       )}
 
       {error && (
-        <div className="bg-opacity-20 mt-4 rounded-lg bg-red-500 p-4 text-red-100">{error}</div>
+        <div className="mt-4 rounded-lg bg-red-500/20 p-4 text-red-100">{error}</div>
       )}
     </div>
   );

--- a/src/pages/PartyBus.tsx
+++ b/src/pages/PartyBus.tsx
@@ -154,6 +154,8 @@ export const PartyBus = () => {
 
   // Track presence channel reference for cleanup
   const presenceRef = useRef<ReturnType<typeof supabase.channel>>();
+  // Pending removal timeouts keyed by nickname — cancelled if player reconnects in time
+  const pendingRemovals = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
     if (roomId && nickname) {
@@ -240,11 +242,22 @@ export const PartyBus = () => {
         })
         .on('presence', { event: 'join' }, ({ key }: { key: string }) => {
           console.log('Player joined:', key);
+          // Cancel any pending removal if the player reconnected
+          const pending = pendingRemovals.current.get(key);
+          if (pending !== undefined) {
+            window.clearTimeout(pending);
+            pendingRemovals.current.delete(key);
+          }
           fetchPlayers();
         })
         .on('presence', { event: 'leave' }, ({ key }: { key: string }) => {
           console.log('Player left:', key);
-          removePlayer(key);
+          // Grace period before removing — brief disconnects should not kick players
+          const timeout = window.setTimeout(() => {
+            removePlayer(key);
+            pendingRemovals.current.delete(key);
+          }, 5000);
+          pendingRemovals.current.set(key, timeout);
         })
         .subscribe(async (status) => {
           if (status === 'SUBSCRIBED') {
@@ -297,6 +310,10 @@ export const PartyBus = () => {
         if (presenceTimeout) {
           window.clearTimeout(presenceTimeout);
         }
+
+        // Cancel all pending player removals
+        pendingRemovals.current.forEach((t) => window.clearTimeout(t));
+        pendingRemovals.current.clear();
 
         // Leave presence channel
         if (presenceRef.current) {

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -4,6 +4,7 @@ import { getCardCounts } from '../api/getCardCounts';
 import { CardCountBarChart } from '../components/CardCountBarChart/CardCountBarChart';
 import { CardCountTable } from '../components/CardCountTable/CardCountTable';
 import { queryKeys } from '../lib/queryKeys';
+import { Button } from '../components/ui/Button';
 
 export type CardCount = {
   card_rank: string;
@@ -64,30 +65,18 @@ export const Stats = (): JSX.Element => {
       <CardCountBarChart cardCounts={sortedCardCounts} />
 
       <div className="my-6 flex justify-center gap-3">
-        <button
-          className="mr-2 rounded bg-blue-500 px-4 py-2 text-white hover:cursor-pointer hover:bg-blue-400"
-          onClick={() => setSortCriteria('rank')}
-        >
+        <Button variant="ghost" onClick={() => setSortCriteria('rank')}>
           Sort by Rank
-        </button>
-        <button
-          className="mr-2 rounded bg-blue-500 px-4 py-2 text-white hover:cursor-pointer hover:bg-blue-400"
-          onClick={() => setSortCriteria('suit')}
-        >
+        </Button>
+        <Button variant="ghost" onClick={() => setSortCriteria('suit')}>
           Sort by Suit
-        </button>
-        <button
-          className="mr-2 rounded bg-blue-500 px-4 py-2 text-white hover:cursor-pointer hover:bg-blue-400"
-          onClick={() => setSortCriteria('count')}
-        >
+        </Button>
+        <Button variant="ghost" onClick={() => setSortCriteria('count')}>
           Sort by Count
-        </button>
-        <button
-          className="rounded bg-blue-500 px-4 py-2 text-white hover:cursor-pointer hover:bg-blue-400"
-          onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
-        >
+        </Button>
+        <Button variant="ghost" onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}>
           {sortOrder === 'asc' ? 'Ascending' : 'Descending'}
-        </button>
+        </Button>
       </div>
 
       <CardCountTable cardCounts={sortedCardCounts} />


### PR DESCRIPTION
## Summary

- **Broadcast instead of DB writes for in-game actions**: Every guess was writing a full \`game_state\` JSON blob to \`party_bus_players\` via a postgres WAL event. Now each player sends a lightweight \`channel.send()\` broadcast event that Supabase fans out to all room subscribers without touching the DB. DB writes only happen at checkpoints: redraw, game over, and win.
- **Fixed a latent card mismatch bug**: The \`DRAW_CARDS\` reducer was calling \`drawCards()\` internally, generating different cards than the ones computed in \`redrawCards()\`. Local state and DB snapshots had different hands. Reducer now accepts \`cards\` directly from the action payload.
- **5-second grace period on presence leave**: A brief disconnect or mobile network hiccup no longer permanently removes a player from the room. The removal fires after 5 seconds; if the player reconnects first, the pending removal is cancelled.
- **40 new tests**: Pure reducer unit tests (23) and hook integration tests (17) covering broadcast subscription, checkpoint logic, and round outcomes.

## Test plan

- [ ] Host creates a room, joiner navigates to the share link
- [ ] Both players appear in the lobby; player list updates in real time
- [ ] Host starts game; both clients enter \`PartyGame\`
- [ ] Each guess by one player updates the Other Players panel on the other client - verify no DB write fires for correct guesses (can check Supabase dashboard)
- [ ] Wrong guess or win triggers a DB checkpoint write
- [ ] Joiner briefly closes tab and reopens link; rejoins and state recovers
- [ ] Both players win; leaderboard appears with correct drink counts
- [ ] \`npx tsc --noEmit\` clean
- [ ] \`npm test\` - 40 new tests pass (ignore pre-existing Netlify plugin failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)